### PR TITLE
fix: outdent indented numbered-list item (1 tutorial)

### DIFF
--- a/tutorials/spa-academy-salesorder/spa-academy-salesorder.md
+++ b/tutorials/spa-academy-salesorder/spa-academy-salesorder.md
@@ -92,7 +92,7 @@ There are many use cases where you can make a difference using SAP Build Process
 
     > The form **Identifier** field is auto-filled.
 
-  3. You are navigated to the Process Builder canvas.
+3. You are navigated to the Process Builder canvas.
 
      This is a visual canvas on which you map out your business process from start to finish. Other process artifacts are then added to this canvas, with process controls and connectors used to decide how information flows when the process is running.
 


### PR DESCRIPTION
## Summary

Outdents 1 numbered-list item in `spa-academy-salesorder` so it sits flush with siblings `1.` and `2.` instead of being interpreted by CommonMark as a nested `<ol start="3">`. Detected by [`tutorials-ims/scripts/lint-tutorial-markdown.ts`](https://github.com/sap-tutorials/tutorials-ims/blob/main/scripts/lint-tutorial-markdown.ts) and tracked in [tutorials-ims#193](https://github.com/sap-tutorials/tutorials-ims/issues/193).

## Changes

| Tutorial | Line | Fix |
|---|---|---|
| `spa-academy-salesorder` | L95 | Outdent `3. You are navigated to the Process Builder canvas.` from 2-space indent to flush-left to match siblings `1.` and `2.` |

CommonMark continuation content (image, prose under item 3) retains its existing indent.

## Verification

Run [`lint-tutorial-markdown`](https://github.com/sap-tutorials/tutorials-ims/blob/main/scripts/lint-tutorial-markdown.ts) against a fresh `.tutorial-cache/` after merge — this tutorial should drop off the report.

## Related

- Platform-side fix: [tutorials-ims#190](https://github.com/sap-tutorials/tutorials-ims/pull/190) (merged)
- Author-side lint: [tutorials-ims#191](https://github.com/sap-tutorials/tutorials-ims/pull/191) (merged)
- Original report: [tutorials-ims#168](https://github.com/sap-tutorials/tutorials-ims/issues/168) (closed)
- Tracking: [tutorials-ims#193](https://github.com/sap-tutorials/tutorials-ims/issues/193)
